### PR TITLE
⚡ Optimize sequential host-device synchronization by grouping tuple fetches

### DIFF
--- a/scripts/benchmark_train_step.py
+++ b/scripts/benchmark_train_step.py
@@ -154,11 +154,12 @@ def main() -> None:
     print(f"Steady step avg: {avg_ms:.2f} ms")
     print(f"Steady step p50: {p50_ms:.2f} ms")
     print(f"Steady step p95: {p95_ms:.2f} ms")
+    loss_host, var_host, pmove_host = jax.device_get((loss_val, var_val, pmove))
     print(
         "Last stats: "
-        f"loss={float(jax.device_get(loss_val)):.6f}, "
-        f"variance={float(jax.device_get(var_val)):.6f}, "
-        f"pmove={float(jax.device_get(pmove)):.4f}"
+        f"loss={float(loss_host):.6f}, "
+        f"variance={float(var_host):.6f}, "
+        f"pmove={float(pmove_host):.4f}"
     )
 
 


### PR DESCRIPTION
💡 **What:** Replaced sequential `jax.device_get` calls with a grouped tuple fetch in `scripts/benchmark_train_step.py`. Note: `src/ferminet/train.py` was already previously optimized with packed stats arrays and a single `jax.device_get` fetch.
🎯 **Why:** Fetching multiple values from device to host sequentially forces multiple pipeline-halting host-device synchronizations. Fetching them as a tuple in one go batches the transfers, reducing synchronization overhead.
📊 **Measured Improvement:** The steady-state benchmark for the training loop is already heavily optimized, but grouping the final stats fetches avoids unnecessary overhead right before output generation.

---
*PR created automatically by Jules for task [1556657221394927888](https://jules.google.com/task/1556657221394927888) started by @spirlness*