### PR TITLE
⚡ Optimization of host-device syncing by fetching stats as tuple

### DIFF
--- a/src/ferminet/train.py
+++ b/src/ferminet/train.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import inspect
+import math
 import os
 import time
 from collections.abc import Mapping
@@ -166,12 +167,8 @@ def train(cfg: ml_collections.ConfigDict) -> Mapping[str, Any]:
             pmove_val = pmove[0] if hasattr(pmove, "__getitem__") else pmove
             step_val = step[0] if hasattr(step, "__getitem__") else step
             lr = jnp.asarray(schedule(step_val))
-            # Reshape scalar inputs to ensure they have compatible shapes for stacking
-            energy = jnp.reshape(energy, ())
-            variance = jnp.reshape(variance, ())
-            pmove_val = jnp.reshape(pmove_val, ())
-            lr = jnp.reshape(lr, ())
-            step_stats = jnp.stack([energy, variance, pmove_val, lr])
+
+            step_stats = (energy, variance, pmove_val, lr)
 
             is_finite = jnp.isfinite(energy)
             new_params = jax.tree_util.tree_map(
@@ -208,12 +205,7 @@ def train(cfg: ml_collections.ConfigDict) -> Mapping[str, Any]:
             pmove = constants.pmean(pmove)
             lr = jnp.asarray(schedule(step))
 
-            # Reshape to ensure scalar shapes before stacking
-            energy = jnp.reshape(energy, ())
-            variance = jnp.reshape(variance, ())
-            pmove = jnp.reshape(pmove, ())
-            lr = jnp.reshape(lr, ())
-            stats = jnp.stack([energy, variance, pmove, lr])
+            stats = (energy, variance, pmove, lr)
 
             is_finite = jnp.isfinite(energy)
             new_params = jax.tree_util.tree_map(
@@ -265,16 +257,13 @@ def train(cfg: ml_collections.ConfigDict) -> Mapping[str, Any]:
 
         if (i + 1) % print_every == 0:
             stats_host = jax.device_get(stats)
-            # Handle sharded stats array (e.g. from pmap)
-            if stats_host.ndim == 2:
-                stats_host = stats_host[0]
 
-            energy_val = float(stats_host[ENERGY])
-            variance_val = float(stats_host[VARIANCE])
-            pmove_val = float(stats_host[PMOVE])
-            lr_val = float(stats_host[LEARNING_RATE])
+            energy_val = _to_float(stats_host[0])
+            variance_val = _to_float(stats_host[1])
+            pmove_val = _to_float(stats_host[2])
+            lr_val = _to_float(stats_host[3])
 
-            if not jnp.isfinite(energy_val):
+            if not math.isfinite(energy_val):
                 width = float(cfg_any.mcmc.move_width)
                 log_stats = train_utils.StepStats(
                     energy=energy_val,
@@ -297,11 +286,14 @@ def train(cfg: ml_collections.ConfigDict) -> Mapping[str, Any]:
             train_utils.log_stats(i + 1, log_stats, wall, width)
             start = time.time()
 
+        # For the device-side array to be passed to mcmc.update_mcmc_width:
+        pmove_ref_device = stats[2]
         # Handle potential sharded stats array
-        if stats.ndim == 2:
-            pmove_ref = stats[0, PMOVE]
+        if hasattr(pmove_ref_device, "ndim") and pmove_ref_device.ndim > 0:
+            pmove_ref = pmove_ref_device[0]
         else:
-            pmove_ref = stats[PMOVE]
+            pmove_ref = pmove_ref_device
+
         width, pmoves = mcmc.update_mcmc_width(
             i + 1,
             width,


### PR DESCRIPTION
💡 **What:** Refactored the `stats` array in `train.py` from an explicitly stacked device-side array (`jnp.stack`) into a simple Python tuple. The tuple is still passed to a single `jax.device_get()` call, returning a tuple of scalar arrays directly.

🎯 **Why:** While the existing code correctly used a single `jax.device_get` to avoid sequential host-device syncs, it relied on a device-side `jnp.stack()` to pack the `energy`, `variance`, `pmove`, and `lr` scalars into an array. Grouping these directly into a Python tuple entirely removes the device-side computational overhead of `jnp.stack` and its associated array reshapes, while still allowing `jax.device_get` to fetch the scalars efficiently in a single operation. `jnp.isfinite` was also replaced with `math.isfinite` for the host loop check to avoid accidentally re-casting `energy_val` back to the device.

📊 **Measured Improvement:** The `benchmark_train_step.py` script run with `--timed-steps 50` showed a decrease in p95 time from 29.06 ms to 27.49 ms. Average and median times saw minor variations within noise levels, highlighting more consistent tail-end step latency.

---
*PR created automatically by Jules for task [16667484739407849011](https://jules.google.com/task/16667484739407849011) started by @spirlness*