### PR TITLE
⚡ Vectorize MCMC data initialization

### DIFF
--- a/src/ferminet/train_utils.py
+++ b/src/ferminet/train_utils.py
@@ -167,11 +167,9 @@ def init_mcmc_data(
     key, subkey = jax.random.split(key)
     positions = jax.random.normal(subkey, (batch_size, n_electrons * ndim))
     if atoms.shape[0] > 0:
-        for i in range(n_electrons):
-            atom_idx = i % atoms.shape[0]
-            positions = positions.at[:, i * ndim : (i + 1) * ndim].add(
-                atoms[atom_idx : atom_idx + 1]
-            )
+        atom_indices = jnp.arange(n_electrons) % atoms.shape[0]
+        offsets = atoms[atom_indices].reshape(-1)
+        positions = positions + offsets
     spins_arr = jnp.array([0] * spins[0] + [1] * spins[1])
     return types.FermiNetData(
         positions=positions,


### PR DESCRIPTION
💡 What:
Replaced a sequential Python loop that used JAX's .at[].add() syntax for updating walker positions with a vectorized addition using broadcasting in src/ferminet/train_utils.py.

🎯 Why:
The original code performed N separate updates to the positions array (where N is the number of electrons). In JAX, this is a well-known anti-pattern. Each .at[].add() call effectively creates a new array or a buffered update, which can lead to multiple kernel launches and large HLO graphs.

📊 Measured Improvement:
Direct measurement was impractical due to environment limitations (lack of JAX and network access). However, this change follows standard JAX performance best practices and provides a guaranteed reduction in dispatch overhead and improved parallelism on the device.

---
*PR created automatically by Jules for task [12790321227005357598](https://jules.google.com/task/12790321227005357598) started by @spirlness*