### PR TITLE
🧹 Refactor MCMC state into NamedTuples

### DIFF
--- a/src/ferminet/mcmc.py
+++ b/src/ferminet/mcmc.py
@@ -3,7 +3,7 @@
 NOTE: these functions operate on batches of MCMC configurations.
 """
 
-from typing import Callable, TypeAlias, TypeVar, cast
+from typing import Callable, NamedTuple, TypeVar, cast
 
 import jax
 import jax.numpy as jnp
@@ -12,9 +12,39 @@ from jax import lax
 from ferminet.types import FermiNetData, LogFermiNetLike, ParamTree
 from ferminet.utils.numerics import EPS
 
-MCMCState: TypeAlias = tuple[
-    FermiNetData, jax.Array, jnp.ndarray, jnp.ndarray, jnp.ndarray | None
-]
+
+class WalkerState(NamedTuple):
+    """State of the walkers in the MCMC.
+
+    Attributes:
+        positions: Walker positions.
+        log_prob: Log probability (2 * log|psi|).
+        hmean: Harmonic mean distances (or None).
+    """
+
+    positions: jnp.ndarray
+    log_prob: jnp.ndarray
+    hmean: jnp.ndarray | None
+
+
+class MCMCState(NamedTuple):
+    """Full state of the MCMC.
+
+    Attributes:
+        data: MCMC configuration (positions, spins, etc).
+        key: RNG key.
+        log_prob: Current log probability.
+        num_accepts: Running total of accepts.
+        hmean: Current harmonic mean distances.
+    """
+
+    data: FermiNetData
+    key: jax.Array
+    log_prob: jnp.ndarray
+    num_accepts: jnp.ndarray
+    hmean: jnp.ndarray | None
+
+
 T = TypeVar("T")
 
 
@@ -56,57 +86,47 @@ def _harmonic_mean(x: jnp.ndarray, atoms: jnp.ndarray) -> jnp.ndarray:
 
 
 def mh_accept(
-    x1: jnp.ndarray,
-    x2: jnp.ndarray,
-    lp_1: jnp.ndarray,
-    lp_2: jnp.ndarray,
+    current: WalkerState,
+    proposal: WalkerState,
     ratio: jnp.ndarray,
     subkey: jax.Array,
     num_accepts: jnp.ndarray,
-    hmean1: jnp.ndarray | None = None,
-    hmean2: jnp.ndarray | None = None,
-) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray | None]:
+) -> tuple[WalkerState, jnp.ndarray]:
     """Metropolis-Hastings accept/reject step with non-finite guards.
 
     Optimized: accepts a pre-split subkey to avoid redundant PRNG splitting.
     """
     rnd = jnp.log(jax.random.uniform(subkey, shape=ratio.shape))
-    finite_proposal = jnp.isfinite(lp_2) & jnp.isfinite(ratio)
+    finite_proposal = jnp.isfinite(proposal.log_prob) & jnp.isfinite(ratio)
     cond = (ratio > rnd) & finite_proposal
-    x_new = jnp.where(cond[..., None], x2, x1)
-    lp_new = jnp.where(cond, lp_2, lp_1)
+    x_new = jnp.where(cond[..., None], proposal.positions, current.positions)
+    lp_new = jnp.where(cond, proposal.log_prob, current.log_prob)
     num_accepts += jnp.sum(cond)
 
-    if hmean1 is not None and hmean2 is not None:
-        hmean_new = jnp.where(cond[..., None, None, None], hmean2, hmean1)
+    if current.hmean is not None and proposal.hmean is not None:
+        hmean_new = jnp.where(
+            cond[..., None, None, None], proposal.hmean, current.hmean
+        )
     else:
         hmean_new = None
 
-    return x_new, lp_new, num_accepts, hmean_new
+    return WalkerState(positions=x_new, log_prob=lp_new, hmean=hmean_new), num_accepts
 
 
 def mh_update(
     params: ParamTree,
     f: LogFermiNetLike,
-    data: FermiNetData,
-    key: jax.Array,
-    lp_1: jnp.ndarray,
-    num_accepts: jnp.ndarray,
-    hmean_1: jnp.ndarray | None,
+    state: MCMCState,
     stddev: float | jnp.ndarray = 0.02,
     atoms: jnp.ndarray | None = None,
     ndim: int = 3,
-) -> tuple[FermiNetData, jax.Array, jnp.ndarray, jnp.ndarray, jnp.ndarray | None]:
+) -> MCMCState:
     """Performs one MH step using all-electron move.
 
     Args:
         params: Network parameters.
         f: Log wavefunction network.
-        data: MCMC configuration.
-        key: RNG key.
-        lp_1: Current log probability (2 * log|psi|).
-        num_accepts: Running total of accepts.
-        hmean_1: Current harmonic mean distances (or None).
+        state: Current MCMC state.
         stddev: Proposal standard deviation. Can be a scalar (same for all
             electrons) or a per-electron array of shape ``(n_electrons,)``
             for shell-adaptive proposals.
@@ -114,10 +134,10 @@ def mh_update(
         ndim: Dimensionality.
 
     Returns:
-        (new_data, key, lp_new, num_accepts, hmean_new)
+        New MCMC state.
     """
-    key, subkey, subkey_accept = jax.random.split(key, num=3)
-    positions, spins, atoms_data, charges = _asarray_data(data)
+    key, subkey, subkey_accept = jax.random.split(state.key, num=3)
+    positions, spins, atoms_data, charges = _asarray_data(state.data)
     x1: jnp.ndarray = positions
 
     if atoms is None:
@@ -134,14 +154,15 @@ def mh_update(
             stddev_broad = stddev_arr
         x2 = x1 + stddev_broad * noise
         lp_2 = 2.0 * f(params, x2, spins, atoms_data, charges)
-        ratio = lp_2 - lp_1
+        ratio = lp_2 - state.log_prob
         hmean_2 = None
         x2_flat = x2
     else:
         # Asymmetric proposal scaled by harmonic mean to atoms
         n = x1.shape[0]
         x1 = jnp.reshape(x1, [n, -1, 1, ndim])
-        # Use passed hmean_1 if available, otherwise compute it
+        # Use passed hmean if available, otherwise compute it
+        hmean_1 = state.hmean
         if hmean_1 is None:
             hmean_1 = _harmonic_mean(x1, atoms)
 
@@ -154,25 +175,30 @@ def mh_update(
         # Forward and reverse probabilities for detailed balance
         lq_1 = _log_prob_gaussian(x1, x2, stddev * hmean_1)
         lq_2 = _log_prob_gaussian(x2, x1, stddev * hmean_2)
-        ratio = lp_2 + lq_2 - lp_1 - lq_1
+        ratio = lp_2 + lq_2 - state.log_prob - lq_1
 
         x1 = jnp.reshape(x1, [n, -1])
 
-    x_new, lp_new, num_accepts, hmean_new = mh_accept(
-        x1,
-        x2_flat,
-        lp_1,
-        lp_2,
+    current = WalkerState(positions=x1, log_prob=state.log_prob, hmean=state.hmean)
+    proposal = WalkerState(positions=x2_flat, log_prob=lp_2, hmean=hmean_2)
+
+    new_walker, num_accepts = mh_accept(
+        current,
+        proposal,
         ratio,
         subkey_accept,
-        num_accepts,
-        hmean_1,
-        hmean_2,
+        state.num_accepts,
     )
 
     # Update data with new positions
-    new_data = data._replace(positions=x_new)
-    return new_data, key, lp_new, num_accepts, hmean_new
+    new_data = state.data._replace(positions=new_walker.positions)
+    return MCMCState(
+        data=new_data,
+        key=key,
+        log_prob=new_walker.log_prob,
+        num_accepts=num_accepts,
+        hmean=new_walker.hmean,
+    )
 
 
 def _log_prob_gaussian(
@@ -216,7 +242,7 @@ def make_mcmc_step(
     ) -> tuple[FermiNetData, jnp.ndarray]:
         def step_fn(_: int, x: MCMCState) -> MCMCState:
             return mh_update(
-                params, batch_network, *x, stddev=width, atoms=atoms, ndim=ndim
+                params, batch_network, x, stddev=width, atoms=atoms, ndim=ndim
             )
 
         positions, spins, atoms_data, charges = _asarray_data(data)
@@ -230,12 +256,15 @@ def make_mcmc_step(
             hmean_init = None
 
         num_accepts_init = jnp.array(0.0)
-        new_data, key, _, num_accepts, _ = _fori_loop(
-            0, steps, step_fn, (data, key, logprob, num_accepts_init, hmean_init)
+        final_state = _fori_loop(
+            0,
+            steps,
+            step_fn,
+            MCMCState(data, key, logprob, num_accepts_init, hmean_init),
         )
 
-        pmove = num_accepts / (steps * batch_per_device)
-        return new_data, pmove
+        pmove = final_state.num_accepts / (steps * batch_per_device)
+        return final_state.data, pmove
 
     return mcmc_step
 

--- a/tests/test_mcmc_helpers.py
+++ b/tests/test_mcmc_helpers.py
@@ -29,15 +29,18 @@ def test_mh_accept_rejects_non_finite_proposals():
     key = jax.random.PRNGKey(0)
     num_accepts = jnp.array(0.0)
 
-    new_positions, new_lp, accepts, new_hmean = mcmc.mh_accept(
-        x1, x2, lp1, lp2, ratio, key, num_accepts
-    )
+    current = mcmc.WalkerState(positions=x1, log_prob=lp1, hmean=None)
+    proposal = mcmc.WalkerState(positions=x2, log_prob=lp2, hmean=None)
 
-    assert jnp.array_equal(new_positions[0], x1[0])  # non-finite proposal rejected
-    assert jnp.array_equal(new_positions[1], x2[1])
+    new_walker, accepts = mcmc.mh_accept(current, proposal, ratio, key, num_accepts)
+
+    assert jnp.array_equal(
+        new_walker.positions[0], x1[0]
+    )  # non-finite proposal rejected
+    assert jnp.array_equal(new_walker.positions[1], x2[1])
     assert accepts > 0
-    assert jnp.isfinite(new_lp[1])
-    assert new_hmean is None
+    assert jnp.isfinite(new_walker.log_prob[1])
+    assert new_walker.hmean is None
 
 
 def test_log_prob_gaussian_and_width_update_behaviour():
@@ -95,22 +98,25 @@ def test_mh_update_without_atoms_modifies_positions():
 
     lp1 = jnp.zeros((2,))
     num_accepts = jnp.array(0.0)
-    new_data, _, _, new_accepts, new_hmean = mcmc.mh_update(
-        params={},
-        f=dummy_network,
+    state = mcmc.MCMCState(
         data=data,
         key=jax.random.PRNGKey(0),
-        lp_1=lp1,
+        log_prob=lp1,
         num_accepts=num_accepts,
-        hmean_1=None,
+        hmean=None,
+    )
+    new_state = mcmc.mh_update(
+        params={},
+        f=dummy_network,
+        state=state,
         stddev=0.1,
         atoms=None,
         ndim=2,
     )
 
-    assert new_data.positions.shape == positions.shape
-    assert new_accepts >= 0.0
-    assert new_hmean is None
+    assert new_state.data.positions.shape == positions.shape
+    assert new_state.num_accepts >= 0.0
+    assert new_state.hmean is None
 
 
 def test_mh_update_with_atoms_updates_hmean():
@@ -135,19 +141,23 @@ def test_mh_update_with_atoms_updates_hmean():
     x_reshaped = jnp.reshape(positions, [batch, nelec, 1, ndim])
     hmean_init = mcmc._harmonic_mean(x_reshaped, atoms)
 
-    new_data, _, _, new_accepts, new_hmean = mcmc.mh_update(
-        params={},
-        f=dummy_network,
+    state = mcmc.MCMCState(
         data=data,
         key=jax.random.PRNGKey(0),
-        lp_1=lp1,
+        log_prob=lp1,
         num_accepts=num_accepts,
-        hmean_1=hmean_init,
+        hmean=hmean_init,
+    )
+
+    new_state = mcmc.mh_update(
+        params={},
+        f=dummy_network,
+        state=state,
         stddev=0.1,
         atoms=atoms,
         ndim=ndim,
     )
 
-    assert new_data.positions.shape == positions.shape
-    assert new_hmean is not None
-    assert new_hmean.shape == hmean_init.shape
+    assert new_state.data.positions.shape == positions.shape
+    assert new_state.hmean is not None
+    assert new_state.hmean.shape == hmean_init.shape


### PR DESCRIPTION
🎯 **What:** Grouped multiple individual parameters in `mh_accept` and `mh_update` into `WalkerState` and `MCMCState` `NamedTuple` objects.

💡 **Why:** This improves maintainability and readability by reducing the number of parameters and clearly organizing related data.

✅ **Verification:** Updated `tests/test_mcmc_helpers.py` to match the new signatures and verified the code with `ruff check`.

✨ **Result:** A cleaner, more maintainable MCMC implementation.

---
*PR created automatically by Jules for task [782604263280281434](https://jules.google.com/task/782604263280281434) started by @spirlness*